### PR TITLE
fix: `SnappyCodec.compress` should accept `Encoder` instance

### DIFF
--- a/src/codec/SnappyCodec.ts
+++ b/src/codec/SnappyCodec.ts
@@ -1,5 +1,9 @@
 import { compress, uncompress } from "snappy";
 
+interface IEncoder {
+    buffer: Buffer
+}
+
 export class SnappyCodec {
 
     private static XERIAL_HEADER = Buffer.from([130, 83, 78, 65, 80, 80, 89, 0])
@@ -14,8 +18,8 @@ export class SnappyCodec {
         return buffer.subarray(0, 8).equals(SnappyCodec.XERIAL_HEADER)
     }
 
-    private async compress(msg: string): Promise<Buffer> {
-        return compress(msg);
+    private async compress(encoder: IEncoder): Promise<Buffer> {
+        return compress(encoder.buffer);
     }
 
     private async decompress(buffer: Buffer): Promise<string | Buffer> {


### PR DESCRIPTION
**Changes**:
* fix: Accept an `Encoder` instance, and pass `Encoder.buffer` to Snappy's `compress` function.
   
   kafkajs doesn't seem to expose types for `Encoder`, so I've just defined an interface. See https://github.com/tulios/kafkajs/issues/1552 for more information.

fixes #1 

---

Thanks for providing a TypeScript alternative to kafkajs-snappy!